### PR TITLE
Copy URL include https://

### DIFF
--- a/src/TinyBlazorAdmin/Pages/UrlManager.razor
+++ b/src/TinyBlazorAdmin/Pages/UrlManager.razor
@@ -32,7 +32,7 @@ else
                     <Template>
                         @{
                             var url = (context as ShortUrlEntity);
-                            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="@(() => CopyToClipboardAsync(url.ShortUrl))">Copy</button>
+                            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="@(() => CopyToClipboardAsync("https://" + url.ShortUrl))">Copy</button>
                         }
                     </Template>
                 </GridColumn>


### PR DESCRIPTION
The copied URL should include the "https://" prefix as proposed in https://github.com/FBoucher/AzUrlShortener/issues/298